### PR TITLE
Add assembly run without redirect method

### DIFF
--- a/src/clr/mod.rs
+++ b/src/clr/mod.rs
@@ -170,6 +170,15 @@ impl Clr {
         self.get_redirected_output()
     }
 
+    pub fn run_no_redirect(&mut self) -> Result<String, String> {
+        let context = self.get_context()?;
+        let assembly = unsafe { (*(&context).app_domain).load_assembly(&self.contents)? };
+
+        unsafe { (*assembly).run_entrypoint(&self.arguments)? };
+        
+        Ok("".to_string())
+    }
+
     pub fn redirect_output(&mut self) -> Result<(), String> {
         let context = self.get_context()?;
 


### PR DESCRIPTION
Hey,

this pull request adds the capability of loading an assembly without output redirection. This way, also interactive C# assemblies can be loaded/executed from memory. Without this method, such assemblies would lead to the application hanging and waiting endlessly for the final output. e.G. an interactive Powershell Runspace:

![image](https://github.com/user-attachments/assets/89d1e143-9740-41ec-b737-0f4c541bd2b3)

Greetings
